### PR TITLE
build: support 2024.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "cat.wavy"
-version = "1.5.0"
+version = "1.5.1"
 
 repositories {
     mavenCentral()
@@ -38,7 +38,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("231")
-        untilBuild.set("241.*")
+        untilBuild.set("242.*")
     }
 
     signPlugin {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,8 +22,7 @@
   ]]></description>
 
     <change-notes>
-        Added an option in the menu (Tools) to reconnect to Discord.
-        Also, notifications are now displayed when connection with Discord is lost.
+        Added support for IntelliJ IDEA 2024.2
     </change-notes>
 
     <!-- Product and plugin compatibility requirements.


### PR DESCRIPTION
### Summary

This PR updates the build configuration to support version 2024.2 of JetBrains IDE

### Testing
- The plugin was successfully built and tested within IntelliJ IDEA running version 2024.2 (IU-242.20224.300)
- All existing functionality remains intact and behaves as expected